### PR TITLE
Add Simple EarlGrey Tests to friendlyping iOS app.

### DIFF
--- a/ios/FriendlyPing.xcodeproj/project.pbxproj
+++ b/ios/FriendlyPing.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		14F433D25FCAE7397B56557F /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 53ECDA2BCE56D9E4FAE51200 /* libPods.a */; };
 		2C29A5A81B2BC6F900A7CB16 /* ClientListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C29A5A71B2BC6F900A7CB16 /* ClientListDataSource.swift */; };
 		2C595EF41B2F979F00355AE7 /* logotype-xxhdpi.png in Resources */ = {isa = PBXBuildFile; fileRef = 2C595EF21B2F979F00355AE7 /* logotype-xxhdpi.png */; };
 		2C595F061B34B73A00355AE7 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C595F041B34B73A00355AE7 /* Constants.swift */; };
@@ -21,7 +20,19 @@
 		5F5A537E1ADE67D500F81DF0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5A537D1ADE67D500F81DF0 /* AppDelegate.swift */; };
 		5F5A53801ADE67D500F81DF0 /* FPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5A537F1ADE67D500F81DF0 /* FPViewController.swift */; };
 		5F5A539C1ADE69AA00F81DF0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5F5A53591ADE670C00F81DF0 /* Main.storyboard */; };
+		FD2E74091C7BCC9500D00352 /* FriendlyPingSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2E74081C7BCC9500D00352 /* FriendlyPingSwiftTests.swift */; };
+		FD2E74151C7BCF2500D00352 /* EarlGrey.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2E74131C7BCF2500D00352 /* EarlGrey.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		FD2E740B1C7BCC9500D00352 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5F5A53441ADE670C00F81DF0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5F5A53781ADE67D500F81DF0;
+			remoteInfo = FriendlyPingSwift;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		2C29A5A71B2BC6F900A7CB16 /* ClientListDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientListDataSource.swift; sourceTree = "<group>"; };
@@ -43,6 +54,11 @@
 		5F5A537F1ADE67D500F81DF0 /* FPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FPViewController.swift; sourceTree = "<group>"; };
 		5F5A539B1ADE695B00F81DF0 /* BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
 		69EA7451507DCFDCD3B32AF2 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		FD2E74061C7BCC9500D00352 /* FriendlyPingSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FriendlyPingSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD2E74081C7BCC9500D00352 /* FriendlyPingSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendlyPingSwiftTests.swift; sourceTree = "<group>"; };
+		FD2E740A1C7BCC9500D00352 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FD2E74131C7BCF2500D00352 /* EarlGrey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EarlGrey.swift; sourceTree = "<group>"; };
+		FD2E74141C7BCF2500D00352 /* FriendlyPingSwiftTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FriendlyPingSwiftTests-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -50,7 +66,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				14F433D25FCAE7397B56557F /* libPods.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD2E74031C7BCC9500D00352 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,6 +104,7 @@
 			children = (
 				2C85627A1AFAB65F00F0B24B /* shared */,
 				5F5A537A1ADE67D500F81DF0 /* FriendlyPingSwift */,
+				FD2E74071C7BCC9500D00352 /* FriendlyPingSwiftTests */,
 				5F5A534D1ADE670C00F81DF0 /* Products */,
 				3C09F4A15D185302D921FF28 /* Pods */,
 				AD1F1C80A93A096F652504F5 /* Frameworks */,
@@ -92,6 +115,7 @@
 			isa = PBXGroup;
 			children = (
 				5F5A53791ADE67D500F81DF0 /* FriendlyPingSwift.app */,
+				FD2E74061C7BCC9500D00352 /* FriendlyPingSwiftTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -130,6 +154,17 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		FD2E74071C7BCC9500D00352 /* FriendlyPingSwiftTests */ = {
+			isa = PBXGroup;
+			children = (
+				FD2E74131C7BCF2500D00352 /* EarlGrey.swift */,
+				FD2E74141C7BCF2500D00352 /* FriendlyPingSwiftTests-Bridging-Header.h */,
+				FD2E74081C7BCC9500D00352 /* FriendlyPingSwiftTests.swift */,
+				FD2E740A1C7BCC9500D00352 /* Info.plist */,
+			);
+			path = FriendlyPingSwiftTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -153,13 +188,31 @@
 			productReference = 5F5A53791ADE67D500F81DF0 /* FriendlyPingSwift.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FD2E74051C7BCC9500D00352 /* FriendlyPingSwiftTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FD2E740F1C7BCC9500D00352 /* Build configuration list for PBXNativeTarget "FriendlyPingSwiftTests" */;
+			buildPhases = (
+				FD2E74021C7BCC9500D00352 /* Sources */,
+				FD2E74031C7BCC9500D00352 /* Frameworks */,
+				FD2E74041C7BCC9500D00352 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FD2E740C1C7BCC9500D00352 /* PBXTargetDependency */,
+			);
+			name = FriendlyPingSwiftTests;
+			productName = FriendlyPingSwiftTests;
+			productReference = FD2E74061C7BCC9500D00352 /* FriendlyPingSwiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		5F5A53441ADE670C00F81DF0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Google Inc.";
 				TargetAttributes = {
@@ -171,6 +224,10 @@
 								enabled = 1;
 							};
 						};
+					};
+					FD2E74051C7BCC9500D00352 = {
+						CreatedOnToolsVersion = 7.3;
+						TestTargetID = 5F5A53781ADE67D500F81DF0;
 					};
 				};
 			};
@@ -188,6 +245,7 @@
 			projectRoot = "";
 			targets = (
 				5F5A53781ADE67D500F81DF0 /* FriendlyPingSwift */,
+				FD2E74051C7BCC9500D00352 /* FriendlyPingSwiftTests */,
 			);
 		};
 /* End PBXProject section */
@@ -202,6 +260,13 @@
 				2C8562851AFAB65F00F0B24B /* Images.xcassets in Resources */,
 				5F5A539C1ADE69AA00F81DF0 /* Main.storyboard in Resources */,
 				2C8562831AFAB65F00F0B24B /* Icon@2x.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD2E74041C7BCC9500D00352 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -271,7 +336,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FD2E74021C7BCC9500D00352 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD2E74151C7BCF2500D00352 /* EarlGrey.swift in Sources */,
+				FD2E74091C7BCC9500D00352 /* FriendlyPingSwiftTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		FD2E740C1C7BCC9500D00352 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5F5A53781ADE67D500F81DF0 /* FriendlyPingSwift */;
+			targetProxy = FD2E740B1C7BCC9500D00352 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		5F5A53591ADE670C00F81DF0 /* Main.storyboard */ = {
@@ -409,6 +491,37 @@
 			};
 			name = Release;
 		};
+		FD2E740D1C7BCC9500D00352 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				INFOPLIST_FILE = FriendlyPingSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.samples.apps.friendlyping.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "FriendlyPingSwiftTests/FriendlyPingSwiftTests-Bridging-Header.h";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FriendlyPingSwift.app/FriendlyPingSwift";
+			};
+			name = Debug;
+		};
+		FD2E740E1C7BCC9500D00352 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				INFOPLIST_FILE = FriendlyPingSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.samples.apps.friendlyping.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "FriendlyPingSwiftTests/FriendlyPingSwiftTests-Bridging-Header.h";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FriendlyPingSwift.app/FriendlyPingSwift";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -426,6 +539,15 @@
 			buildConfigurations = (
 				5F5A53951ADE67D500F81DF0 /* Debug */,
 				5F5A53961ADE67D500F81DF0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FD2E740F1C7BCC9500D00352 /* Build configuration list for PBXNativeTarget "FriendlyPingSwiftTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FD2E740D1C7BCC9500D00352 /* Debug */,
+				FD2E740E1C7BCC9500D00352 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/FriendlyPing.xcodeproj/xcshareddata/xcschemes/FriendlyPingSwiftTests.xcscheme
+++ b/ios/FriendlyPing.xcodeproj/xcshareddata/xcschemes/FriendlyPingSwiftTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FD2E74051C7BCC9500D00352"
+               BuildableName = "FriendlyPingSwiftTests.xctest"
+               BlueprintName = "FriendlyPingSwiftTests"
+               ReferencedContainer = "container:FriendlyPing.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/FriendlyPing/Base.lproj/Main.storyboard
+++ b/ios/FriendlyPing/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="zxq-GO-nHP">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10089" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="zxq-GO-nHP">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10072.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -20,6 +20,9 @@
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logotype-xxhdpi.png" translatesAutoresizingMaskIntoConstraints="NO" id="v6b-cZ-Lky">
                                 <rect key="frame" x="160" y="276" width="280" height="49"/>
+                                <accessibility key="accessibilityConfiguration" identifier="signup-screen-banner">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="49" id="WDh-2L-lty"/>
                                     <constraint firstAttribute="width" constant="280" id="aOL-xB-wug"/>
@@ -27,6 +30,7 @@
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The fastest way to send and receive friendly pings." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jWQ-ht-bkW">
                                 <rect key="frame" x="157" y="330" width="287.5" height="14.5"/>
+                                <accessibility key="accessibilityConfiguration" identifier="signup-screen-label"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -34,6 +38,7 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qDo-1s-Eg5">
                                 <rect key="frame" x="200" y="404" width="200" height="28"/>
                                 <color key="backgroundColor" red="0.50196078431372548" green="0.87058823529411766" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <accessibility key="accessibilityConfiguration" identifier="signup-screen-signin-button"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="flz-PA-XTM"/>
                                 </constraints>

--- a/ios/FriendlyPingSwiftTests/EarlGrey.swift
+++ b/ios/FriendlyPingSwiftTests/EarlGrey.swift
@@ -1,0 +1,73 @@
+//
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+public func EarlGrey() -> EarlGreyImpl {
+  return EarlGreyImpl.invokedFromFile(__FILE__, lineNumber: __LINE__)
+}
+
+public func GREYAssert(@autoclosure expression: () -> BooleanType, reason: String) {
+  GREYAssert(expression, reason, details: "Expected expression to be true")
+}
+
+public func GREYAssertTrue(@autoclosure expression: () -> BooleanType, reason: String) {
+  GREYAssert(expression().boolValue,
+             reason,
+             details: "Expected the boolean expression to be true")
+}
+
+public func GREYAssertFalse(@autoclosure expression: () -> BooleanType, reason: String) {
+  GREYAssert(!expression().boolValue,
+             reason,
+             details: "Expected the boolean expression to be true")
+}
+
+public func GREYAssertNotNil(@autoclosure expression: () -> Any?, reason: String) {
+  GREYAssert(expression() != nil, reason, details: "Expected expression to be not nil")
+}
+
+public func GREYAssertNil(@autoclosure expression: () -> Any?, reason: String) {
+  GREYAssert(expression() == nil, reason, details: "Expected expression to be nil")
+}
+
+public func GREYAssertEqual<T : Equatable>(@autoclosure left: () -> T?,
+    @autoclosure _ right: () -> T?, reason: String) {
+  GREYAssert(left() == right(), reason, details: "Expeted left term to be equal to right term")
+}
+
+public func GREYFail(reason: String) {
+  greyFailureHandler.handleException(GREYFrameworkException(name: kGREYAssertionFailedException,
+    reason: reason), details: "")
+}
+
+public func GREYFail(reason: String, details: String) {
+  greyFailureHandler.handleException(GREYFrameworkException(name: kGREYAssertionFailedException,
+    reason: reason), details: details)
+}
+
+private func GREYAssert(@autoclosure expression: () -> BooleanType,
+                        _ reason: String, details: String) {
+  GREYSetCurrentAsFailable()
+  if !expression().boolValue {
+    greyFailureHandler.handleException(GREYFrameworkException(name: kGREYAssertionFailedException,
+      reason: reason), details: details)
+  }
+}
+
+private func GREYSetCurrentAsFailable() {
+  if greyFailureHandler.respondsToSelector(Selector("setInvocationFile:andInvocationLine:")) {
+    greyFailureHandler.setInvocationFile!(__FILE__, andInvocationLine: __LINE__)
+  }
+}

--- a/ios/FriendlyPingSwiftTests/FriendlyPingSwiftTests-Bridging-Header.h
+++ b/ios/FriendlyPingSwiftTests/FriendlyPingSwiftTests-Bridging-Header.h
@@ -1,0 +1,17 @@
+//
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <EarlGrey/EarlGrey.h>

--- a/ios/FriendlyPingSwiftTests/FriendlyPingSwiftTests.swift
+++ b/ios/FriendlyPingSwiftTests/FriendlyPingSwiftTests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+class FriendlyPingSwiftTests: XCTestCase {
+
+  func testInitialSignUpScreenPresent() {
+    EarlGrey().selectElementWithMatcher(grey_accessibilityID("signup-screen-label"))
+        .assertWithMatcher(grey_sufficientlyVisible())
+    EarlGrey().selectElementWithMatcher(grey_accessibilityID("signup-screen-banner"))
+        .assertWithMatcher(grey_sufficientlyVisible())
+    EarlGrey().selectElementWithMatcher(grey_accessibilityID("signup-screen-signin-button"))
+        .assertWithMatcher(grey_sufficientlyVisible())
+  }
+
+  // Since EarlGrey does not handle System Dialogs, for this test to run correctly, please
+  // accept the System Dialog to accept Notifications.
+  func testPressSignupScreenButton() {
+    EarlGrey().selectElementWithMatcher(grey_accessibilityID("signup-screen-signin-button"))
+       .performAction(grey_tap())
+    EarlGrey().selectElementWithMatcher(grey_accessibilityID("signup-screen-label"))
+      .assertWithMatcher(grey_notVisible())
+    EarlGrey().selectElementWithMatcher(grey_accessibilityID("signup-screen-banner"))
+        .assertWithMatcher(grey_notVisible())
+  }
+}

--- a/ios/FriendlyPingSwiftTests/Info.plist
+++ b/ios/FriendlyPingSwiftTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,7 +1,23 @@
 # FriendlyPing
+
+PROJECT_NAME = 'FriendlyPing'
+TEST_TARGET = 'FriendlyPingSwiftTests'
+SCHEME_FILE = 'FriendlyPingSwiftTests.xcscheme'
+
 platform :ios, '8.0'
-target 'FriendlyPingSwift'
-pod 'Google/CloudMessaging'
-pod 'Google/SignIn'
-pod 'Google/AdMob'
-pod 'Google/Analytics'
+target 'FriendlyPingSwift' do
+  pod 'Google/CloudMessaging'
+  pod 'Google/SignIn'
+  pod 'Google/AdMob'
+  pod 'Google/Analytics'
+end
+
+target 'FriendlyPingSwiftTests' do
+  inherit! :search_paths
+  pod 'EarlGrey'
+end
+
+post_install do |installer|
+  load('configure_earlgrey_pods.rb')
+  configure_for_earlgrey(installer, PROJECT_NAME, TEST_TARGET, SCHEME_FILE)
+end

--- a/ios/configure_earlgrey_pods.rb
+++ b/ios/configure_earlgrey_pods.rb
@@ -1,0 +1,196 @@
+#!/usr/bin/ruby
+#
+#  Copyright 2016 Google Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require 'xcodeproj'
+EARLGREY_TARGET_NAME = 'EarlGrey'
+
+def configure_for_earlgrey(installer, project_name, test_target, scheme_file)
+  puts ("Checking and Updating " + project_name + " for EarlGrey.").blue
+  pods_project = installer.pods_project
+
+  if (pods_project.nil? || !File.exist?(project_name + '.xcodeproj'))
+    raise "The target's xcodeproj file could not be found. Please check if "\
+      "the correct PROJECT_NAME is being passed in the Podfile. Current "\
+      "PROJECT_NAME is: " + project_name
+  end
+
+  user_project = Xcodeproj::Project.open(project_name + '.xcodeproj')
+
+  # Add a Test Action to the User Project Scheme.
+  scheme = modify_scheme_for_actions(project_name, user_project, scheme_file)
+
+  # Add a Copy Files Build Phase for EarlGrey.framework to embed it into the app under test.
+  add_earlgrey_copy_files_script(user_project, test_target)
+
+  if not scheme.nil?
+    save_earlgrey_scheme_changes(scheme)
+  end
+  puts ("EarlGrey setup complete. You can use the Test Target : " + test_target +
+      " for EarlGrey testing.").blue
+end
+
+# Scheme changes to ensure that EarlGrey is correctly loaded before main() is called.
+def modify_scheme_for_actions(project_name, user_project, scheme_filename)
+  # If you do not pass on a scheme name, we set it to the project name itself.
+  if scheme_filename.to_s == ''
+    scheme_filename = project_name
+  end
+
+  xcdata_dir = Xcodeproj::XCScheme.user_data_dir(user_project.path)
+  if not File.exist?(File.join(xcdata_dir, scheme_filename).to_s)
+    xcdata_dir = Xcodeproj::XCScheme.shared_data_dir(user_project.path)
+  end
+
+  if not File.exist?(File.join(xcdata_dir, scheme_filename).to_s)
+    raise "The required scheme \"" + scheme_filename +"\" could not be found."
+      " Please ensure that the required scheme file exists within your"\
+      " project directory."
+  end
+  scheme = Xcodeproj::XCScheme.new File.join(xcdata_dir, scheme_filename)
+  test_action_key = 'DYLD_INSERT_LIBRARIES'
+  test_action_value = '@executable_path/EarlGrey.framework/EarlGrey'
+  if not scheme.test_action.xml_element.to_s.include? test_action_value
+    scheme =
+        add_environment_variables_to_test_action_scheme(scheme_filename,
+                                                        scheme,
+                                                        test_action_key, 
+                                                        test_action_value)
+  end
+
+  return scheme
+end
+
+# Load the EarlGrey framework when the app binary is loaded by
+# the dynamic loader, before the main() method is called.
+def add_environment_variables_to_test_action_scheme(scheme_filename,
+                                                    scheme,
+                                                    test_action_key,
+                                                    test_action_value)
+  test_action = scheme.test_action
+  if (scheme.test_action.xml_element.to_s.include? test_action_key) ||
+    (scheme.launch_action.xml_element.to_s.include? test_action_key)
+    puts ("\n//////////////////// EARLGREY SCHEME ISSUE ////////////////////\n"\
+      "EarlGrey failed to modify the Test Action part of the scheme: " + scheme_filename + "\n"\
+      + "for one of following reasons:\n\n"\
+      "1) DYLD_INSERT_LIBRARIES is already defined under Environment Variables of\n"\
+      "the Test Action.\n"\
+      "2) Run Action's environment variables are used for Test Action.\n\n"\
+      "To ensure correct functioning of EarlGrey, please manually add the\n"\
+      "following under Test Action's Environment Variables of the scheme:"  + scheme_filename +  "\n"\
+      "Environment Variables or EarlGrey's location will not be found.\n"\
+      "Name: DYLD_INSERT_LIBRARIES\n"\
+      "Value: @executable_path/EarlGrey.framework/EarlGrey\n"\
+      "///////////////////////////////////////////////////////////////\n\n").yellow
+    return
+  end
+  puts "Adding EarlGrey Framework Location as an Environment Variable "
+    "in the App Project's Test Target's Scheme Test Action."
+
+  # Check if the test action uses the run action's environment variables and arguments.
+  launch_action_env_args_present = false
+  if (scheme.test_action.xml_element.to_s.include? 'shouldUseLaunchSchemeArgsEnv') &&
+      ((scheme.launch_action.xml_element.to_s.include? '<EnvironmentVariables>') ||
+      (scheme.launch_action.xml_element.to_s.include? '<CommandLineArguments>'))
+    launch_action_env_args_present = true
+  end
+
+  test_action_isEnabled = 'YES'
+  test_action.should_use_launch_scheme_args_env = false
+
+  # If no environment variables are set, then create the element itself.
+  if not (scheme.test_action.xml_element.to_s.include? '<EnvironmentVariables>')
+    scheme.test_action.xml_element.add_element('EnvironmentVariables')
+  end
+
+  # If Launch Action Arguments are present and none are present in the test
+  # action, then please add them in.
+  if (scheme.launch_action.xml_element.to_s.include? '<CommandLineArguments>') &&
+      !(scheme.test_action.xml_element.to_s.include? '<CommandLineArguments>')
+    scheme.test_action.xml_element.add_element('CommandLineArguments')
+  end
+
+  # Create a new environment variable and add it to the Environment Variables.
+  test_action_env_vars = scheme.test_action.xml_element.elements['EnvironmentVariables']
+  test_action_args = scheme.test_action.xml_element.elements['CommandLineArguments']
+
+  earl_grey_environment_variable = REXML::Element.new "EnvironmentVariable"
+  earl_grey_environment_variable.attributes['key'] = test_action_key
+  earl_grey_environment_variable.attributes['value'] = test_action_value
+  earl_grey_environment_variable.attributes['isEnabled'] = test_action_isEnabled
+  test_action_env_vars.add_element(earl_grey_environment_variable)
+
+  # If any environment variables or arguments were being used in the test action by
+  # being copied from the launch (run) action then copy them over to the test action
+  # along with the EarlGrey environment variable.
+  if (launch_action_env_args_present)
+    launch_action_env_vars = scheme.launch_action.xml_element.elements['EnvironmentVariables']
+    launch_action_args = scheme.launch_action.xml_element.elements['CommandLineArguments']
+
+    # Add in the Environment Variables
+    launch_action_env_vars.elements.each('EnvironmentVariable') do |launch_action_env_var|
+      environment_variable = REXML::Element.new 'EnvironmentVariable'
+      environment_variable.attributes['key'] = launch_action_env_var.attributes['key']
+      environment_variable.attributes['value'] = launch_action_env_var.attributes['value']
+      environment_variable.attributes['isEnabled'] = launch_action_env_var.attributes['isEnabled']
+      test_action_env_vars.add_element(environment_variable)
+    end
+
+    #Add in the Arguments
+    launch_action_args.elements.each('CommandLineArgument') do |launch_action_arg|
+      argument = REXML::Element.new 'CommandLineArgument'
+      argument.attributes['argument'] = launch_action_arg.attributes['argument']
+      argument.attributes['isEnabled'] = launch_action_arg.attributes['isEnabled']
+      test_action_args.add_element(argument)
+    end
+
+  end
+  scheme.test_action = test_action
+  return scheme
+end
+
+# Generates a copy files build phase to embed the EarlGrey framework into
+# the app under test.
+def add_earlgrey_copy_files_script(user_project, test_target)
+  user_project.targets.each do |target|
+    earlgrey_copy_files_phase_name = 'EarlGrey Copy Files'
+    if target.name == test_target
+      earlgrey_copy_files_exists = false
+      target.copy_files_build_phases.each do |copy_files_phase|
+        if copy_files_phase.name = earlgrey_copy_files_phase_name
+          earlgrey_copy_files_exists = true
+        end
+      end
+
+      if earlgrey_copy_files_exists == false
+        new_copy_files_phase = target.new_copy_files_build_phase(earlgrey_copy_files_phase_name)
+        new_copy_files_phase.dst_path = '$(TEST_HOST)/../'
+        new_copy_files_phase.dst_subfolder_spec = '0'
+        file_ref =
+            user_project.products_group.new_file('${SRCROOT}/Pods/EarlGrey/EarlGrey-1.0.0/EarlGrey.framework')
+        file_ref.source_tree = 'SRCROOT'
+        build_file = new_copy_files_phase.add_file_reference(file_ref, true)
+        build_file.settings = { 'ATTRIBUTES' => ['CodeSignOnCopy'] }
+        user_project.save()
+      end
+    end
+  end
+end
+
+# Save the scheme changes. This is done here to prevent any irreversible changes in case
+# of an exception being thrown.
+def save_earlgrey_scheme_changes(scheme)
+  scheme.save!
+end


### PR DESCRIPTION
Adds [EarlGrey](https://github.com/google/EarlGrey) Tests that check if the Sign-In Screen is displayed and if the Notifications System Dialog has been accepted, taps on the Sign-In Button, verifying that the screen has transitioned.

Adding EarlGrey requires:
- Adding a Test Target - `FriendlyPingSwiftTests` along with a shared Scheme.
- Adding the separate Test Target config with the EarlGrey dependency to the Podfile.
- Copying `configure_earlgrey_pods.rb` to the root directory to allow EarlGrey to modify the project's Scheme and add a Copy Files Build Phase.
